### PR TITLE
[feat] Local Multiplayer

### DIFF
--- a/GBADeltaCore/Bridge/GBAEmulatorBridge.mm
+++ b/GBADeltaCore/Bridge/GBAEmulatorBridge.mm
@@ -282,12 +282,12 @@ int  RGB_LOW_BITS_MASK;
 
 #pragma mark - Inputs -
 
-- (void)activateInput:(NSInteger)gameInput value:(double)value
+- (void)activateInput:(NSInteger)gameInput value:(double)value at:(NSInteger)playerIndex
 {
     self.activatedInputs |= (uint32_t)gameInput;
 }
 
-- (void)deactivateInput:(NSInteger)gameInput
+- (void)deactivateInput:(NSInteger)gameInput at:(NSInteger)playerIndex
 {
     self.activatedInputs &= ~((uint32_t)gameInput);
 }


### PR DESCRIPTION
Though GBA does not support local multiplayer, all cores still need to conform to the updated DeltaCore protocol.